### PR TITLE
Switch product source to WooCommerce

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,3 @@
+WC_KEY=your_woocommerce_key
+WC_SECRET=your_woocommerce_secret
+WOOCOMMERCE_API_BASE=https://example.com

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Crie um arquivo `.env.local` com:
 ```
 TINY_API_TOKEN=sua-chave-aqui
 NEXT_PUBLIC_SITE_URL=https://catalogo-next.netlify.app
+WC_KEY=sua-chave-woocommerce
+WC_SECRET=sua-senha-woocommerce
+WOOCOMMERCE_API_BASE=https://sualoja.com
 ```
 
 ---

--- a/app/_not-found/page.tsx
+++ b/app/_not-found/page.tsx
@@ -1,4 +1,4 @@
-import { fetchProducts } from '@/lib/fetchProducts';
+import { fetchProducts } from '@/lib/fetchProductsWoo';
 import ProductCard from '@/app/components/ProductCard';
 import Link from 'next/link';
 

--- a/app/api/categorias/route.ts
+++ b/app/api/categorias/route.ts
@@ -1,4 +1,4 @@
-import { fetchProducts } from '@/lib/fetchProducts';
+import { fetchProducts } from '@/lib/fetchProductsWoo';
 import { NextResponse } from 'next/server';
 import { isProdutoAtivo } from '@/lib/isProdutoAtivo';
 

--- a/app/api/sugestoes/route.ts
+++ b/app/api/sugestoes/route.ts
@@ -1,4 +1,4 @@
-import { fetchProducts } from '@/lib/fetchProducts';
+import { fetchProducts } from '@/lib/fetchProductsWoo';
 import { isProdutoAtivo } from '@/lib/isProdutoAtivo';
 import { NextResponse } from 'next/server';
 

--- a/app/comparar/CompararPageInner.tsx
+++ b/app/comparar/CompararPageInner.tsx
@@ -7,7 +7,7 @@ import { formatPreco } from '@/lib/formatPrice';
 import { useComparar } from '@/app/context/CompararContext';
 import { useCatalogo } from '@/app/context/CatalogoContext';
 import { useSearchParams, usePathname } from 'next/navigation';
-import { Product } from '@/lib/fetchProducts';
+import { Product } from '@/lib/fetchProductsWoo';
 
 export default function CompararPageInner() {
     const { comparar, adicionar, remover, limpar } = useComparar();

--- a/app/components/ProductCard.tsx
+++ b/app/components/ProductCard.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { formatPreco } from '@/lib/formatPrice';
-import { Product } from '@/lib/fetchProducts';
+import { Product } from '@/lib/fetchProductsWoo';
 import { useCatalogo } from '@/app/context/CatalogoContext';
 import { useComparar } from '@/app/context/CompararContext';
 import { motion } from 'framer-motion';

--- a/app/components/ProductCarousel.tsx
+++ b/app/components/ProductCarousel.tsx
@@ -3,7 +3,7 @@
 import { useKeenSlider } from 'keen-slider/react';
 import 'keen-slider/keen-slider.min.css';
 import ProductCard from './ProductCard';
-import { Product } from '@/lib/fetchProducts';
+import { Product } from '@/lib/fetchProductsWoo';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { isProdutoAtivo } from '@/lib/isProdutoAtivo';

--- a/app/components/ProductList.tsx
+++ b/app/components/ProductList.tsx
@@ -6,7 +6,7 @@ import { useCatalogo } from '@/app/context/CatalogoContext';
 import { motion, AnimatePresence } from 'framer-motion';
 import { filtrarProdutos } from '@/lib/filtrarProdutos';
 import { aliasesCategorias } from '@/lib/aliasesCategorias';
-import { Product } from '@/lib/fetchProducts';
+import { Product } from '@/lib/fetchProductsWoo';
 import { useEffect, useRef, useState } from 'react';
 
 const LIMITE_INICIAL = 20;

--- a/app/components/ProdutosRelacionados.tsx
+++ b/app/components/ProdutosRelacionados.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Product } from '@/lib/fetchProducts';
+import { Product } from '@/lib/fetchProductsWoo';
 import ProductCard from './ProductCard';
 import { isProdutoAtivo } from '@/lib/isProdutoAtivo';
 

--- a/app/components/TabelaParcelamentoProduto.tsx
+++ b/app/components/TabelaParcelamentoProduto.tsx
@@ -3,7 +3,7 @@
 import { useRef, useState } from 'react';
 import * as htmlToImage from 'html-to-image';
 import { Camera } from 'lucide-react';
-import { Product } from '@/lib/fetchProducts';
+import { Product } from '@/lib/fetchProductsWoo';
 import { useCatalogo } from '@/app/context/CatalogoContext';
 import { MdMemory } from 'react-icons/md';
 import { RiSdCardMiniLine } from 'react-icons/ri';

--- a/app/context/CatalogoContext.tsx
+++ b/app/context/CatalogoContext.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { createContext, useContext } from 'react';
-import { Product } from '@/lib/fetchProducts';
+import { Product } from '@/lib/fetchProductsWoo';
 import { Taxa } from '@/lib/fetchTaxas';
 
 interface CatalogoContextProps {

--- a/app/context/CompararContext.tsx
+++ b/app/context/CompararContext.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { createContext, useContext, useEffect, useState } from 'react';
-import { Product } from '@/lib/fetchProducts';
+import { Product } from '@/lib/fetchProductsWoo';
 import { useCatalogo } from './CatalogoContext';
 
 interface CompararContextType {

--- a/app/lista/ListaPageClient.tsx
+++ b/app/lista/ListaPageClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { fetchProducts } from '@/lib/fetchProducts';
+import { fetchProducts } from '@/lib/fetchProductsWoo';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useState, useEffect } from 'react';

--- a/app/produtos/[slug]/ProductPageClient.tsx
+++ b/app/produtos/[slug]/ProductPageClient.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useRef } from 'react';
 import GaleriaProduto from '@/app/components/GaleriaProduto';
 import { formatPreco } from '@/lib/formatPrice';
-import { Product } from '@/lib/fetchProducts';
+import { Product } from '@/lib/fetchProductsWoo';
 import ProdutosRelacionados from '@/app/components/ProdutosRelacionados';
 import { Share2 } from 'lucide-react';
 import { MdOutlineImageNotSupported } from 'react-icons/md';

--- a/app/produtos/[slug]/page.tsx
+++ b/app/produtos/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { fetchProducts } from '@/lib/fetchProducts';
+import { fetchProducts } from '@/lib/fetchProductsWoo';
 import { notFound } from 'next/navigation';
 import ProductPageClient from './ProductPageClient';
 import type { Metadata } from 'next';

--- a/lib/fetchProductsWoo.ts
+++ b/lib/fetchProductsWoo.ts
@@ -1,0 +1,116 @@
+import { Buffer } from 'buffer';
+
+export interface Product {
+    titulo: string;
+    valor: number;
+    promocao?: number;
+    emPromocao: boolean;
+    destaque: boolean;
+    cor?: string;
+    marca?: string;
+    categoria: string;
+    subcategoria?: string;
+    imagemPrincipal?: string;
+    imagem2?: string;
+    imagem3?: string;
+    imagem4?: string;
+    descricao?: string;
+    inativo?: string;
+    ram?: string;
+    armazenamento?: string;
+    slug: string;
+    tem5g?: boolean;
+    temNFC?: boolean;
+    idTiny?: string;
+    estoqueSaldo?: number;
+    disponivel?: boolean;
+}
+
+interface WooCategory { id: number; name: string; }
+interface WooAttribute { name: string; options: string[]; }
+interface WooImage { src: string; }
+interface WooMeta { key: string; value: string; }
+interface WooProduct {
+    name: string;
+    price: string;
+    regular_price: string;
+    sale_price: string;
+    slug: string;
+    categories: WooCategory[];
+    attributes: WooAttribute[];
+    images: WooImage[];
+    stock_quantity: number | null;
+    stock_status: string;
+    description?: string;
+    short_description?: string;
+    featured?: boolean;
+    meta_data: WooMeta[];
+}
+
+function parseNumber(value: string | number | undefined | null): number | undefined {
+    if (value === undefined || value === null) return undefined;
+    const num = typeof value === 'number' ? value : parseFloat(value);
+    return isNaN(num) ? undefined : num;
+}
+
+export async function fetchProducts(): Promise<Product[]> {
+    const base = process.env.WOOCOMMERCE_API_BASE;
+    const key = process.env.WC_KEY;
+    const secret = process.env.WC_SECRET;
+
+    if (!base || !key || !secret) {
+        console.warn('WooCommerce credentials are missing');
+        return [];
+    }
+
+    const auth = Buffer.from(`${key}:${secret}`).toString('base64');
+    const url = `${base.replace(/\/$/, '')}/wp-json/wc/v3/products?per_page=100`;
+
+    const res = await fetch(url, {
+        headers: {
+            Authorization: `Basic ${auth}`,
+        },
+        next: { revalidate: 60 },
+    });
+
+    if (!res.ok) {
+        console.error('Erro ao buscar produtos WooCommerce:', await res.text());
+        throw new Error('Falha ao buscar produtos');
+    }
+
+    const data: WooProduct[] = await res.json();
+
+    return data.map((p) => {
+        const regular = parseNumber(p.regular_price) ?? parseNumber(p.price) ?? 0;
+        const sale = parseNumber(p.sale_price);
+        const marcaAttr = p.attributes.find((a) => /marca|brand/i.test(a.name));
+        const corAttr = p.attributes.find((a) => /cor|color/i.test(a.name));
+        const nfcAttr = p.attributes.find((a) => /nfc/i.test(a.name));
+        const g5Attr = p.attributes.find((a) => /5g/i.test(a.name));
+        const idTinyMeta = p.meta_data?.find((m) => m.key.toLowerCase() === 'idtiny');
+
+        return {
+            titulo: p.name,
+            valor: regular,
+            promocao: sale,
+            emPromocao: typeof sale === 'number' && sale > 0 && sale < regular,
+            destaque: !!p.featured,
+            cor: corAttr?.options[0],
+            marca: marcaAttr?.options[0],
+            categoria: p.categories[0]?.name || '',
+            subcategoria: p.categories[1]?.name,
+            imagemPrincipal: p.images[0]?.src,
+            imagem2: p.images[1]?.src,
+            imagem3: p.images[2]?.src,
+            imagem4: p.images[3]?.src,
+            descricao: p.description || p.short_description,
+            inativo: p.stock_status === 'instock' ? 'false' : 'true',
+            slug: p.slug,
+            tem5g: !!g5Attr,
+            temNFC: !!nfcAttr,
+            idTiny: idTinyMeta?.value,
+            estoqueSaldo: parseNumber(p.stock_quantity),
+            disponivel: p.stock_status === 'instock',
+        } as Product;
+    });
+}

--- a/lib/filtrarProdutos.ts
+++ b/lib/filtrarProdutos.ts
@@ -1,4 +1,4 @@
-import { Product } from './fetchProducts';
+import { Product } from './fetchProductsWoo';
 import { isProdutoAtivo } from './isProdutoAtivo';
 
 interface Filtros {

--- a/lib/getCatalogoData.ts
+++ b/lib/getCatalogoData.ts
@@ -1,5 +1,5 @@
 // lib/getCatalogoData.ts
-import { fetchProducts } from './fetchProducts';
+import { fetchProducts } from './fetchProductsWoo';
 import { fetchTaxas } from './fetchTaxas';
 
 export async function getCatalogoData() {

--- a/lib/isProdutoAtivo.ts
+++ b/lib/isProdutoAtivo.ts
@@ -1,6 +1,6 @@
 // lib/isProdutoAtivo.ts
 
-import { Product } from './fetchProducts';
+import { Product } from './fetchProductsWoo';
 
 /**
  * Retorna true se o produto estiver ativo (ou seja, não marcado como inativo e com estoque se aplicável).


### PR DESCRIPTION
## Summary
- add WooCommerce credentials placeholders to `.env.local`
- document WooCommerce env vars
- add `fetchProductsWoo` helper to load WooCommerce products
- use the new helper across the app

## Testing
- `npm run lint`
- `npm run build` *(fails: fetch failed during prerender)*

------
https://chatgpt.com/codex/tasks/task_e_6848ed645fd483219c012a4e7a9ef62f