### PR TITLE
Switch categories API to WooCommerce

### DIFF
--- a/app/components/HeaderCategorias.tsx
+++ b/app/components/HeaderCategorias.tsx
@@ -6,10 +6,14 @@ import { ChevronDown } from 'lucide-react';
 import clsx from 'clsx';
 import getIconeCategoria from '@/lib/IconeCategoria';
 
-type Menu = Record<string, string[]>;
+interface MenuCategoria {
+    id: number;
+    name: string;
+    children: MenuCategoria[];
+}
 
 export default function HeaderCategorias() {
-    const [menu, setMenu] = useState<Menu>({});
+    const [menu, setMenu] = useState<MenuCategoria[]>([]);
     const [categoriaAberta, setCategoriaAberta] = useState<string | null>(null);
     const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -36,7 +40,7 @@ export default function HeaderCategorias() {
         return () => document.removeEventListener('mousedown', handleClickOutside);
     }, [categoriaAberta]);
 
-    const todasCategorias = Object.keys(menu);
+    const todasCategorias = menu.map((c) => c.name);
     const categoriasSemPromocoes = todasCategorias.filter(
         (c) => c.toLowerCase() !== 'promoções'
     );
@@ -45,7 +49,8 @@ export default function HeaderCategorias() {
     );
 
     const handleCategoriaClick = (categoria: string, e: React.MouseEvent) => {
-        const temSub = menu[categoria]?.length > 0;
+        const cat = menu.find((c) => c.name === categoria);
+        const temSub = cat?.children.length ? true : false;
 
         if (window.innerWidth < 768) {
             if (temSub) {
@@ -65,7 +70,8 @@ export default function HeaderCategorias() {
                 <ul className="flex flex-wrap justify-center gap-4 md:gap-6 text-sm ">
                     {principaisCategorias.map((categoria) => {
                         const isAberta = categoriaAberta === categoria;
-                        const temSub = menu[categoria]?.length > 0;
+                        const cat = menu.find((c) => c.name === categoria);
+                        const temSub = cat?.children.length ? true : false;
 
                         return (
                             <li key={categoria} className="relative group">
@@ -117,16 +123,16 @@ export default function HeaderCategorias() {
                                                 Ver tudo
                                             </Link>
                                         </li>
-                                        {menu[categoria].map((sub) => (
-                                            <li key={sub}>
+                                        {cat?.children.map((sub) => (
+                                            <li key={sub.id}>
                                                 <Link
                                                     href={`/categorias/${encodeURIComponent(
                                                         categoria
-                                                    )}/${encodeURIComponent(sub)}`}
+                                                    )}/${encodeURIComponent(sub.name)}`}
                                                     onClick={fecharDropdownMobile}
                                                     className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition"
                                                 >
-                                                    {sub}
+                                                    {sub.name}
                                                 </Link>
                                             </li>
                                         ))}

--- a/app/components/HeaderTop.tsx
+++ b/app/components/HeaderTop.tsx
@@ -25,7 +25,11 @@ import { loja } from '@/app/config/lojaConfig';
 
 const SearchBox = dynamic(() => import('./SearchBox'), { ssr: false });
 
-type MenuEstrutura = Record<string, string[]>;
+interface MenuCategoria {
+    id: number;
+    name: string;
+    children: MenuCategoria[];
+}
 
 export default function HeaderTop({
     menuAberto,
@@ -34,7 +38,7 @@ export default function HeaderTop({
     menuAberto: boolean;
     setMenuAberto: Dispatch<SetStateAction<boolean>>;
 }) {
-    const [menu, setMenu] = useState<MenuEstrutura>({});
+    const [menu, setMenu] = useState<MenuCategoria[]>([]);
     const asideRef = useRef<HTMLDivElement | null>(null);
     const touchStartX = useRef(0);
 
@@ -134,29 +138,29 @@ export default function HeaderTop({
                             </div>
 
                             <ul className="space-y-4">
-                                {Object.entries(menu).map(([categoria, subcategorias]) => {
-                                    const subs = [...subcategorias];
+                                {menu.map((categoria) => {
+                                    const subs = [...categoria.children];
                                     const xiaomiIndex = subs.findIndex(
-                                        (s) => s.toLowerCase() === 'xiaomi'
+                                        (s) => s.name.toLowerCase() === 'xiaomi'
                                     );
                                     if (xiaomiIndex > 0) {
                                         const [xiaomi] = subs.splice(xiaomiIndex, 1);
                                         subs.unshift(xiaomi);
                                     }
                                     return (
-                                        <li key={categoria}>
+                                        <li key={categoria.id}>
                                             <div className="flex items-center gap-2 text-sm font-semibold text-gray-800">
                                                 <span className="text-gray-500">
-                                                    {getIconeCategoria(categoria)}
+                                                    {getIconeCategoria(categoria.name)}
                                                 </span>
-                                                {categoria}
+                                                {categoria.name}
                                             </div>
 
                                             <ul className="mt-3 pl-4 pr-3 space-y-2">
                                                 <li>
                                                     <Link
                                                         href={`/produtos?categoria=${encodeURIComponent(
-                                                            categoria
+                                                            categoria.name
                                                         )}`}
                                                         onClick={() => setMenuAberto(false)}
                                                         className="block text-sm text-blue-600 font-medium hover:underline"
@@ -165,15 +169,15 @@ export default function HeaderTop({
                                                     </Link>
                                                 </li>
                                                 {subs.map((sub) => (
-                                                    <li key={sub}>
+                                                    <li key={sub.id}>
                                                         <Link
                                                             href={`/categorias/${encodeURIComponent(
-                                                                categoria
-                                                            )}/${encodeURIComponent(sub)}`}
+                                                                categoria.name
+                                                            )}/${encodeURIComponent(sub.name)}`}
                                                             onClick={() => setMenuAberto(false)}
                                                             className="block text-sm text-gray-700 hover:underline"
                                                         >
-                                                            {sub}
+                                                            {sub.name}
                                                         </Link>
                                                     </li>
                                                 ))}

--- a/lib/fetchCategoriesWoo.ts
+++ b/lib/fetchCategoriesWoo.ts
@@ -1,0 +1,36 @@
+import { Buffer } from 'buffer';
+
+export interface WooCategory {
+  id: number;
+  name: string;
+  parent: number;
+}
+
+export async function fetchCategories(): Promise<WooCategory[]> {
+  const base = process.env.WOOCOMMERCE_API_BASE;
+  const key = process.env.WC_KEY;
+  const secret = process.env.WC_SECRET;
+
+  if (!base || !key || !secret) {
+    console.warn('WooCommerce credentials are missing');
+    return [];
+  }
+
+  const auth = Buffer.from(`${key}:${secret}`).toString('base64');
+  const url = `${base.replace(/\/$/, '')}/wp-json/wc/v3/products/categories?per_page=100`;
+
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Basic ${auth}`,
+    },
+    next: { revalidate: 60 },
+  });
+
+  if (!res.ok) {
+    console.error('Erro ao buscar categorias WooCommerce:', await res.text());
+    throw new Error('Falha ao buscar categorias');
+  }
+
+  const data: WooCategory[] = await res.json();
+  return data.map(({ id, name, parent }) => ({ id, name, parent }));
+}


### PR DESCRIPTION
## Summary
- add `fetchCategoriesWoo` helper
- rewrite `/api/categorias` route to call WooCommerce categories
- update header components to consume new category structure

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6848f163b16c8321a71196d68297135b